### PR TITLE
Add ARM support

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1109,9 +1109,16 @@ void hp_sample_check(hp_entry_t **entries  TSRMLS_DC) {
 static inline uint64 cycle_timer() {
   uint32 __a,__d;
   uint64 val;
+#if defined(__x86_64__)
   asm volatile("rdtsc" : "=a" (__a), "=d" (__d));
   (val) = ((uint64)__a) | (((uint64)__d)<<32);
   return val;
+#elif defined(__ARM_ARCH)
+  struct timeval now;
+  if (gettimeofday(&now, NULL) == 0) {
+    return now.tv_sec * 1000000 + now.tv_usec;
+  }
+#endif
 }
 
 /**


### PR DESCRIPTION
Currently the `cycle_timer()` function uses assembly to get the current time (I think!), which isn't available on ARM.

Inspired by how Tideways XHPRof has worked around this: https://github.com/tideways/php-xhprof-extension/blob/master/timer.h#L27